### PR TITLE
[BUGFIX] Add registration of backend rendering files

### DIFF
--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+templates.typo3/cms-backend.1741003348 = fgtclb/academic-programs:Resources/Private/Backend


### PR DESCRIPTION
With TYPO3 12.0 the rendering and override of backend files changed. To automatically render the extension-shipped partial for the extension-registered Doktype, add the `page.tsconfig` with registration globally.

With `page_backend_layout` not installed (see #3), this won't have any effect and keeps the rendering default.

Fixes #4