### PR TITLE
[BUGFIX] Use `$_EXTKEY` in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$EM_CONF['academic_programs'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => '(FGTCLB) University Educational Program',
     'description' => 'Educational Program page for TYPO3 with structured data based on sys_category',
     'category' => 'fe',


### PR DESCRIPTION
Uploading a release for classic mode to the
TYPO3 Extension Repository (TER) requires
that `$_EXTKEY` is used instead of a hard
coded extension key within the `ext_emconf.php`
file. Otherwise the validation cannot find
the version and rejects the upload.
