### PR TITLE
[BUGFIX] Ensure loading `PageTsConfig` for new content elements wizard

### DIFF
--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,3 +1,6 @@
 @import 'EXT:academic_programs/Configuration/TsConfig/Page/BackendLayouts/*.tsconfig'
+@import 'EXT:academic_programs/Configuration/TsConfig/Page/*.tsconfig'
 
+# Following only works in TYPO3 v12+ and has no impact in TYPO3 v11
+# and therefore no condition is needed here to cover this.
 templates.typo3/cms-backend.1730990129 = fgtclb/academic-programs:Resources/Private/Backend


### PR DESCRIPTION
With commit [1] including the `PageTsConfig` for the
new content element wizards has been removed while
adding TYPO3 v12 backend template path configuration
effectly no longer loading this definition. That was
done original on the compatibility branch (v11/v12/v13)
and not detected because the TYPO3 v13 site sets still
included it and only broke this partly for `sys_template`
based instances and TYPO3 v11 and v12.

This change adds an import statement again to load
new content element wizard reladed `PageTsConfig`
in non site-sets (TYPO3 v13) based setups, which is
not supported by 1.x.x but prepares for TYPO3 v13
support in 2.x.x.

[1] 3059f72f62d351929dcc15bcc44072515f70c3b9
